### PR TITLE
Mileage can only be increasing

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -270,7 +270,8 @@ class MileageToyotaDevice(ToyotaDomoticzDevice):
             if self.exists():
                 mileage = vehicle_status.odometer.mileage
                 diff = mileage - self._last_mileage
-                if diff != 0:
+                if diff > 0:
+                    # Mileage can only go up
                     Devices[self._unit_index].Update(nValue=0, sValue=f'{diff}')
                     self._last_mileage = mileage
 


### PR DESCRIPTION
To resolve potential problems with passing negative mileage differences to Domoticz, we only update the mileage if it is incrementing.
If due to a problem of Toyota a mileage is reported that is lower than a previous value, (like old data or a previous data, or a bug) it will thus not be updated to Domoticz.