### PR TITLE
Validate sensors exist before checking doors status.

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -505,7 +505,7 @@ class LockedToyotaDevice(ToyotaDomoticzDevice):
     def _get_doors(self, vehicle_status):    # pylint:disable=no-self-use
         """Return an array of individual door instances"""
         doors = []
-        if vehicle_status and vehicle_status.sensors.doors:
+        if vehicle_status and vehicle_status.sensors and vehicle_status.sensors.doors:
             direct = vehicle_status.sensors.doors
             try:
                 doors = [direct.driver_seat, direct.passenger_seat,


### PR DESCRIPTION
Check sensors property exists for this vehicle before checking the doors.

Not all vehicle provide locked status (for exemple Corolla from 2020), in this case, mytoyota API will return None for the sensors property.
This fix an error when checking locking status that prevent others devices to be created.